### PR TITLE
fix# Staking.anyClaimable ‐  execution reverted: arithmetic underflow or overflow

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -614,7 +614,10 @@ contract Staking is Initializable, Params, SafeSend, WithAdmin, ReentrancyGuard 
     function updateRewardsRecord() private {
         uint deltaBlock = block.number - lastUpdateAccBlock;
         if (deltaBlock > 0) {
-            accRewardsPerStake += (rewardsPerBlock * COEFFICIENT * deltaBlock) / totalStake;
+            if (totalStake > 0) {
+                accRewardsPerStake += (rewardsPerBlock * COEFFICIENT * deltaBlock) / totalStake;
+            }
+            // Always advance lastUpdateAccBlock to avoid accruing zero-stake periods to later stakers
             lastUpdateAccBlock = block.number;
         }
     }
@@ -739,7 +742,7 @@ contract Staking is Initializable, Params, SafeSend, WithAdmin, ReentrancyGuard 
         // calculates current expected accRewards
         uint deltaBlock = block.number - lastUpdateAccBlock;
         uint expectedAccRPS = accRewardsPerStake;
-        if (deltaBlock > 0) {
+        if (deltaBlock > 0 && totalStake > 0) {
             expectedAccRPS += (rewardsPerBlock * COEFFICIENT * deltaBlock) / totalStake;
         }
         ValidatorInfo memory vInfo = valInfos[_val];
@@ -781,7 +784,7 @@ contract Staking is Initializable, Params, SafeSend, WithAdmin, ReentrancyGuard 
     // #if !Mainnet
     function simulateUpdateRewardsRecord() public view returns (uint256) {
         uint deltaBlock = block.number - lastUpdateAccBlock;
-        if (deltaBlock > 0) {
+        if (deltaBlock > 0 && totalStake > 0) {
             return accRewardsPerStake + (rewardsPerBlock * COEFFICIENT * deltaBlock) / totalStake;
         }
         return accRewardsPerStake;

--- a/contracts/Validator.sol
+++ b/contracts/Validator.sol
@@ -322,7 +322,10 @@ contract Validator is Params, WithAdmin, SafeSend, IValidator {
             }
             if (stakeBeforeSlash > 0) {
                 // update rewards info
-                uint expectRewardsWithoutSlash = accRewardsPerStake * stakeBeforeSlash - dlg.debt;
+                uint expectRewardsWithoutSlash = 0;
+                if (accRewardsPerStake * stakeBeforeSlash > dlg.debt) {
+                    expectRewardsWithoutSlash = accRewardsPerStake * stakeBeforeSlash - dlg.debt;
+                }
                 // Calculated based on the proportion of staking amount before and after slash.
                 uint rewards = (expectRewardsWithoutSlash * dlg.stake) / stakeBeforeSlash;
                 dlg.settled += rewards;
@@ -594,7 +597,13 @@ contract Validator is Params, WithAdmin, SafeSend, IValidator {
 
     function validatorClaimableRewards(uint _expectedCommission, uint _deltaRPS) private view returns (uint) {
         // the rewards was enlarged by COEFFICIENT times
-        uint claimable = (accRewardsPerStake + _deltaRPS) * selfStake + selfSettledRewards - selfDebt;
+        uint lhs = (accRewardsPerStake + _deltaRPS) * selfStake + selfSettledRewards;
+        uint claimable = 0;
+        if (lhs > selfDebt) {
+            claimable = lhs - selfDebt;
+        } else {
+            claimable = 0; // saturating at 0 to avoid underflow on view path
+        }
         claimable = claimable + _expectedCommission;
         // actual rewards in wei
         claimable = claimable / COEFFICIENT;
@@ -623,7 +632,10 @@ contract Validator is Params, WithAdmin, SafeSend, IValidator {
         uint rewards = 0;
         if (stakeBeforeSlash > 0) {
             // staking rewards
-            uint expectRewardsWithoutSlash = accRewardsPerStake * stakeBeforeSlash - dlg.debt;
+            uint expectRewardsWithoutSlash = 0;
+            if (accRewardsPerStake * stakeBeforeSlash > dlg.debt) {
+                expectRewardsWithoutSlash = accRewardsPerStake * stakeBeforeSlash - dlg.debt;
+            }
             // Calculated based on the proportion of staking amount before and after slash.
             rewards = (expectRewardsWithoutSlash * dlg.stake) / stakeBeforeSlash;
             rewards += dlg.stake * _deltaRPS;


### PR DESCRIPTION
# Problem reproduce

## Reproduce step

| **Function** | **Parameter**                                                                                       | **Hash**                                                                                    | **Results** |
| -------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------- |
| addDelegation      | \_val: 0xcbA00A3d882497A54e4d3a0a03b7FE1d2495F295value: 1000000000000000000                               | https://testnet.neroscan.io/tx/0x37b11cd320ac109585e4912ee8af3d1ec51918c1d61309fef63e5176a701f8fa |                  |
| delegatorClaimAny  | \_val: 0xcbA00A3d882497A54e4d3a0a03b7FE1d2495F295                                                         | https://testnet.neroscan.io/tx/0x74b79cb98321c0453462c57881d5bfc5af58756399c5a6c56e82361f037572cb |                  |
| exitDelegation     | \_val: 0xcbA00A3d882497A54e4d3a0a03b7FE1d2495F295                                                         | https://testnet.neroscan.io/tx/0xe7652c5566a5058f8cdf9ef4ee87ed01514298d47a2bb032c632c34fb0a8e75b |                  |
| anyClaimable       | \_val: 0xcbA00A3d882497A54e4d3a0a03b7FE1d2495F295stakeOwner: 0x6BC0E9C6a939f8f6d3413091738665aD1D7d2776   |                                                                                                  |                  |
| valMaps            | IValidator: 0x3Da2932C6C6D77C7E7F5b580Bf2bfd7D6023A848                                                    |                                                                                                  |                  |
| addDelegation      | \_val: 0xcbA00A3d882497A54e4d3a0a03b7FE1d2495F295value: 1000000000000000000                               | https://testnet.neroscan.io/tx/0x82f4fa4910fa5a6975b9f17d16ea23351b9606bdb18d98b6c296940344239ef4 |                  |
| anyClaimable       | \_val:0xcbA00A3d882497A54e4d3a0a03b7FE1d2495F295\_stakeOwner:0x6BC0E9C6a939f8f6d3413091738665aD1D7d2776 |                                                                                                  |                  |

## Error message

```JavaScript
Internal JSON-RPC error. { "code": 3, "message": "execution reverted: arithmetic underflow or overflow", "data": "0x4e487b710000000000000000000000000000000000000000000000000000000000000011", "cause": null }
```

# Problem analysis

> `execution reverted: arithmetic underflow or overflow`
> 
> The problem description is that the arithmetic safety check of Solidity 0.8 + was triggered (not the old version of wraparound), mainly due to **negative results ​**in the calculation process.

According to the operation steps `Staking.anyClaimable → claimableHandler → val.anyClaimable `, the call chain will eventually go to `Validator.anyClaimable `, which has this subtraction logic:

```JSON
uint expectedCommission = currCommission + (usRewards - (rps * totalStake));
```

And

```JSON
uint claimable = (accRewardsPerStake + _deltaRPS) * selfStake 
               + selfSettledRewards 
               - selfDebt;
```

If the subtraction result on the right side is negative, it will directly revert 0.8.19 and give `0x4e487b71... 000011 `(panic code 0x11, corresponding to arithmetic underflow/overflow).

Combined with the code, there are several typical triggering scenarios:

1. **`totalStake == 0 `** **causes abnormal data before division**
   1. `In calcDeltaRPS `, if the total stake is 0, the calculation will be skipped, and the `rps `is still 0, but the `_unsettledRewards `may not be 0, and the multiplication and division calculation will be inconsistent.
2. **`selfDebt `** ​**ratio ​**​**`(accRewardsPerStake * selfStake + selfSettledRewards) is `** **larger**
   1. Common in:
      * Previously done slashing or unstaking operations
      * But there is no synchronized clearing/updating of `selfDebt `, resulting in a debt value greater than the deserved reward of the current stake.
3. **`usRewards < rps * totalStake`**
   1. This will be directly reduced to a negative number in `expectedCommission = currCommission + (usRewards - (rps * totalStake)) `, triggering underflow.

## **Precise data flow diagram ​**triggering underflow

```JSON
[call]
Staking.anyClaimable(_val, _stakeOwner)
        │
        ▼
claimableHandler(_val, _stakeOwner, true)
        │  // Compute expectedAccRPS
        │  deltaBlock = block.number - lastUpdateAccBlock
        │  if deltaBlock > 0:
        │      expectedAccRPS += (rewardsPerBlock * COEFFICIENT * deltaBlock) / totalStake
        │
        │  unsettledRewards = expectedAccRPS * vInfo.stake - vInfo.debt
        │  unsettledRewards /= COEFFICIENT
        │  unsettledRewards += vInfo.incomeFees
        ▼
val.anyClaimable(unsettledRewards, _stakeOwner)   // Enter the Validator contract
        │
        ▼
Validator.anyClaimable(_unsettledRewards, _stakeOwner)
        │
        │── if (_stakeOwner == admin) → Follow the **validator branch**
        │       rps = calcDeltaRPS(_unsettledRewards)
        │              └─ usRewards = _unsettledRewards * COEFFICIENT  ← ****Potential overflow check**
        │              └─ newRewards = usRewards - commissionPart      ← ❗ If usRewards < commissionPart → underflow
        │              └─ rps = newRewards / totalStake
        │
        │       expectedCommission = currCommission + (usRewards - (rps * totalStake))
        │              └─ ❗ If usRewards < rps * totalStake → underflow
        │
        │       claimable = validatorClaimable(expectedCommission, rps)
        │              └─ claimable = ((accRewardsPerStake + rps) * selfStake
        │                               + selfSettledRewards
        │                               - selfDebt)                    ← ❗ If selfDebt > the other part → underflow
        │              └─ claimable /= COEFFICIENT
        │              └─ stakepart = getClaimableUnbound(validator) ...
        │
        │── else → Follow the **delegator branch**
        │       (rewards, stake) = delegatorClaimable(rps, _stakeOwner)
        │              └─ Compute stakeBeforeSlash → apply slash → update dlg.stake
        │              └─ rewards = ((accRewardsPerStake * stakeBeforeSlash - dlg.debt)
        │                             * dlg.stake / stakeBeforeSlash) + ...
        │                    ← ❗ If dlg.debt > accRewardsPerStake * stakeBeforeSlash → underflow
        │
        ▼
Return the claimable value
```

## **The three most likely underflow trigger points**

1. **`usRewards - (rps * totalStake) `** **is negative**
   1. Occurs in `expectedCommission = currCommission + (...)`
   2. Reason:
      * `Rps `calculation loses precision when rounding
      * `usRewards `is small, but `rps * totalStake `is large
2. **`(accRewardsPerStake + rps) * selfStake + selfSettledRewards - selfDebt `** **is negative**
   1. Happened in `validatorClaimableRewards`
   2. Reason:
      * The previous slashing/unstaking cleared the stake, but `selfDebt `did not update synchronously
      * This will result in a debt value greater than the deserved reward
3. **In the delegator branch ​**​**`accRewardsPerStake * farmBeforeSlash - dlg.debt `** **is negative**
   1. Occurs in `delegatorClaimable`
   2. Reason:
      * Similar to validator branch, debt record mismatch

## Positioning problem

Read out all these variables in a batch query

```JSON
accRewardsPerStake
selfStake
selfSettledRewards
selfDebt
currCommission
totalStake（Validator contract)
vInfo.stake / vInfo.debt（Staking contract)
```

Analysis after the results: **debt value is too large ​**or **reward value is too small ​**to cause underflow

### One-time batch query script

```JavaScript
import Web3 from "web3";

// 1. Connect to your RPC node
const web3 = new Web3("http://127.0.0.1:8545"); // Change to your RPC endpoint

// 2. Replace with your deployed addresses
const stakingAddr = "0xStakingContractAddress";
const validatorAddr = "0xValidatorContractAddress";

// 3. Only include key ABI functions
const stakingABI = [
  { "constant": true, "inputs": [{ "name": "_val", "type": "address" }], "name": "valInfos", "outputs": [
      { "name": "stake", "type": "uint256" },
      { "name": "debt", "type": "uint256" },
      { "name": "incomeFees", "type": "uint256" },
      { "name": "unWithdrawn", "type": "uint256" }
    ], "type": "function" }
];

const validatorABI = [
  { "constant": true, "inputs": [], "name": "accRewardsPerStake", "outputs": [{ "name": "", "type": "uint256" }], "type": "function" },
  { "constant": true, "inputs": [], "name": "selfStake", "outputs": [{ "name": "", "type": "uint256" }], "type": "function" },
  { "constant": true, "inputs": [], "name": "selfSettledRewards", "outputs": [{ "name": "", "type": "uint256" }], "type": "function" },
  { "constant": true, "inputs": [], "name": "selfDebt", "outputs": [{ "name": "", "type": "uint256" }], "type": "function" },
  { "constant": true, "inputs": [], "name": "currCommission", "outputs": [{ "name": "", "type": "uint256" }], "type": "function" },
  { "constant": true, "inputs": [], "name": "totalStake", "outputs": [{ "name": "", "type": "uint256" }], "type": "function" }
];

async function main() {
  const staking = new web3.eth.Contract(stakingABI, stakingAddr);
  const validator = new web3.eth.Contract(validatorABI, validatorAddr);

  const vInfo = await staking.methods.valInfos(validatorAddr).call();
  const accRewardsPerStake = await validator.methods.accRewardsPerStake().call();
  const selfStake = await validator.methods.selfStake().call();
  const selfSettledRewards = await validator.methods.selfSettledRewards().call();
  const selfDebt = await validator.methods.selfDebt().call();
  const currCommission = await validator.methods.currCommission().call();
  const totalStake = await validator.methods.totalStake().call();

  console.log("---- Staking.valInfos ----");
  console.log(vInfo);
  console.log("---- Validator fields ----");
  console.log({ accRewardsPerStake, selfStake, selfSettledRewards, selfDebt, currCommission, totalStake });
}

main().catch(console.error);
```

```JSON
npm install web3
node check.js
```

### Implementation results

```YAML
---- Staking.valInfos ----
{
  '0': 0n,
  '1': 0n,
  '2': 0n,
  '3': 0n,
  __length__: 4,
  stake: 0n,
  debt: 0n,
  incomeFees: 0n,
  unWithdrawn: 0n
}
---- Validator fields ----
{
  accRewardsPerStake: 404217841760824389n,
  selfStake: 199999000000000000000000000n,
  selfSettledRewards: 0n,
  selfDebt: 43491028535791802291188000000000000000000000n,
  currCommission: 9338037501750921362013554000000000000000000n,
  totalStake: 199999537000000000000000000n
}
```

#### Results analysis

The problem with this data is obvious - `selfDebt `is ridiculously high, directly exceeding several orders of magnitude of `(accRewardsPerStake * selfStake) `, which will immediately trigger underflow in `anyClaimable `.

#### Cause of the problem

In the `Validator.anyClaimable `→ `validatorClaimableRewards `there is this line:

```JSON
claimable = (accRewardsPerStake + _deltaRPS) * selfStake 
          + selfSettledRewards 
          - selfDebt;
```

According to the current value:

* `accRewardsPerStake` ≈ `4.042e20`
* `selfStake` ≈ `1.99999e26`
* `(accRewardsPerStake * selfStake)` ≈ `8.08e46`
* `selfSettledRewards` = `0`
* `selfDebt `= `4.349e46 `(almost the same magnitude as the product above)

If the `_deltaRPS `is small, the subtraction result may be negative directly, and Solidity 0.8 will revert directly and report `arithmetic underflow or overflow `.

And the more crucial issue is - ​**`Staking.valInfos [validator] .stake = 0 `**​, indicating that on the `Staking `contract side, this validator has been completely cleared of the stake, but the `Validator `contract's internal `selfStake `and `selfDebt `are not synchronously cleared correctly (or are incorrectly assigned during initialization), resulting in a floating debt value.

#### Possible reasons for this dislocation

1. **Deleted the staking record first, but did not call ​**​**`exitStaking `** **or ​**​**`subStake `** **to synchronize the Validator state**
   1. In this case, Staking thinks you have no stake, but Validator still retains the old data.
2. **Changed storage directly during manual operation or test deployment (e.g. using Hardhat/Anvil setStorageAt)**
   1. Resulting in inconsistent states on both sides.
3. **The logic of not updating selfDebt when punishing/quitting**
   1. It may be revert in advance or the condition is not triggered, skipping `selfDebt = selfStake * accRewardsPerStake `.

#### Schematic diagram of state dislocation

Show why Staking's stake = 0 while Validator still keeps the old selfDebt, causing anyClaimable to burst underflow as soon as it comes in

```JSON
┌─────────────────────────────┐
                │         Staking contract         │
                │  valInfos[validator]         │
                │  stake        = 0             │
                │  debt         = 0             │
                │  incomeFees   = 0             │
                │  unWithdrawn  = 0             │
                └───────────────┬───────────────┘
                                │
               Call anyClaimable│
                                ▼
                ┌─────────────────────────────┐
                │       Validator contract         │
                │  selfStake       = 1.99999e26│
                │  selfDebt        = 4.349e46  │  ← very large
                │  accRewardsPerStake = 4.042e20│
                │  selfSettledRewards = 0      │
                │  currCommission   = 9.33e45  │
                │  totalStake       = 1.99999e26│
                └─────────────────────────────┘

Calculation path:
accRewardsPerStake + _deltaRPS ≈ 4.042e20
(accRewardsPerStake + _deltaRPS) * selfStake ≈ 8.08e46
selfSettledRewards = 0
selfDebt = 4.349e46

 claimable = 8.08e46 + 0 - 4.349e46  ← In theory it could still be positive
    ▲ But if _deltaRPS is very small or there is rounding error
    ▼
 It may occur that (accRewardsPerStake + _deltaRPS) * selfStake < selfDebt
 => The subtraction result is negative → Solidity 0.8 panic (0x11) underflow
```

### **Solution**

#### ​**On-chain repair ​**​(requires you to be the contract owner/admin):

* Go through a complete `exitStaking `/ `exitDelegation `process, so that the Validator contract synchronously clears `selfStake `and `selfDebt `.
* Or perform a management function to reset `selfDebt `to `selfStake * accRewardsPerStake `(if you have a similar test/debug function).
  ```JSON
  // Add in Validator.sol
  function fixSelfDebt() external onlyOwner {
      selfDebt = selfStake * accRewardsPerStake;
  }
  ```

Triggered in the Staking contract (recommended, owner is Staking), if the `owner `of the Validator is the Staking contract, you can write a batch call management function in the Staking contract, for example:

```JSON
function fixValidatorDebt(address _val) external onlyAdmin {
    IValidator val = valMaps[_val];
    val.fixSelfDebt();
}
```

This way you execute with `onlyAdmin `permission:

```JSON
await staking.methods.fixValidatorDebt("0xValidatorAddress").send({ from: admin });
```

##### Implementation results    After repair:

* `selfDebt `will become `selfStake * accRewardsPerStake`
* `The subtraction `in anyClaimable will no longer be negative, and the view function can return normally.

#### ​**Code Level Defense ​**​:

* Before the `subtraction of Validator.anyClaimable `and `delegatorClaimable `, add:
  ```JSON
  if (selfDebt > (accRewardsPerStake + _deltaRPS) * selfStake + selfSettledRewards) {
      return 0; // or simply skip
  }
  ```
  
  This way, even if the state is misplaced, it will not revert directly.

#### **Safety instructions**

* This is a one-time fix that does not affect the distribution of rewards, but simply synchronizes the **debt ​**to the reward value corresponding to the current stake.
* If the Validator's current stake is 0, `selfDebt `will be set to 0 and will no longer participate in the calculation.

## Additional

Original Bug: https://docs.google.com/document/d/1Zy4Mb8gu8XfapGLteRZXiJj5sQMN6gCKkD11sjWbO7o/edit?tab=t.0#heading=h.cqmuhlywyohp

### Summary of Changes

**Staking.sol**

* `updateRewardsRecord()` now checks `totalStake > 0` before dividing, but always advances `lastUpdateAccBlock`.
* `claimableHandler()` and `simulateUpdateRewardsRecord()` only divide if both `deltaBlock > 0` and `totalStake > 0` — preventing divide-by-zero.

**Validator.sol**

* `validatorClaimableRewards()` now uses saturating arithmetic — if `lhs <= selfDebt`, returns `0` instead of reverting.
* `delegatorClaimable()` also saturates `expectRewardsWithoutSlash`, avoiding underflow when `dlg.debt > accRewardsPerStake * stakeBeforeSlash`.