### PR TITLE
Update stake handling in Validator contract to use current stake afte…

### DIFF
--- a/contracts/Validator.sol
+++ b/contracts/Validator.sol
@@ -241,9 +241,11 @@ contract Validator is Params, WithAdmin, SafeSend, IValidator {
 
         handleDelegatorPunishment(_delegator);
 
-        uint oldStake = dlg.stake;
-        RankingOp op = innerSubDelegation(oldStake, _delegator, true);
-        return (op, oldStake);
+        // Use current stake after punishment; punishment may have slashed part of the delegation.
+        uint stakeToExit = delegators[_delegator].stake;
+        require(stakeToExit > 0, "E34");
+        RankingOp op = innerSubDelegation(stakeToExit, _delegator, true);
+        return (op, stakeToExit);
     }
 
     function innerSubDelegation(uint256 _stake, address _delegator, bool _isUnbound) private returns (RankingOp) {


### PR DESCRIPTION
# exitDelegation Revert: Issue Analysis and Conclusion

> This document summarizes the full investigation, root cause, and fix for `execution reverted` when a delegator calls `Staking.exitDelegation`. Intended for sharing with the team.

---

## 1. Problem Summary

### 1.1 Observed Behavior

- **Caller**: `0xa0a73dbcbb0230ddf278cedd8cdf93c6cba1824f` (delegator)
- **Call**: `Staking.exitDelegation(address _val)` with `_val = 0x52D8Fb6216EE63b76D22208E0B474ec124a00965` (validator address)
- **Result**: Transaction failed with `Failed: execution reverted`; no error code surfaced to the user

### 1.2 Environment

| Item | Value |
|------|-------|
| Chain | Nero Testnet |
| Staking contract | `0x000000000000000000000000000000000000f000` |
| Validator (_val) | `0x52D8Fb6216EE63b76D22208E0B474ec124a00965` |
| Validator manager | `0x87070aD5D5C3a023AA0E5E460418E58c95862444` |
| RPC | `https://rpc-testnet.nerochain.io` |
| Failing tx hash | `0xbf139b385843546c0329239b0585b7c6cd40ce7efa3e07f7de8f817ff2682bb1` |
| Failing tx block | 14198997 |

---

## 2. Investigation

### 2.1 Possible Revert Reasons

From the Staking / Validator code path, possible revert points for `exitDelegation`:

| Code | Meaning | Where |
|------|---------|-------|
| E08 | Validator not exists | Staking: `valMaps[_val] == 0` |
| E28 | can't do staking at current state | Validator: `canDoStaking() == false` (e.g. state == Exit) |
| E34 | no delegation | Validator: `delegators[delegator].stake == 0` |
| E24 | no enough stake to subtract/unbind | Validator: `innerSubDelegation` — `dlg.stake < _stake` |
| (none) | Division by zero | Staking: `totalStake == 0` in `updateRewardsRecord` |
| (none) | Arithmetic overflow | Theoretical: e.g. `accRewardsPerStake * stake` under extreme params |

### 2.2 On-Chain State Check

Using `scripts/debug-exit-delegation.js` on **current** chain state:

- Validator is registered, `canDoStaking() == true`, state is Jail
- This delegator has delegation: `stake = 5 ETH`, `debt ≈ 4.25e34` (scaled)

This ruled out E08, E34 (no delegation), and overflow as the cause **at current state**. The failing tx was in a **historical block**, so the exact revert reason was determined by replaying that transaction.

### 2.3 Failing Transaction Analysis

Using `scripts/debug-tx-revert.js` on tx `0xbf139b38...`:

- Fetched tx and receipt (status = 0, reverted)
- Parsed calldata: confirmed `exitDelegation(address)` with `_val = 0x52D8Fb...`
- Replayed the call at the same block to obtain revert data

**Revert reason: E24**

- Revert payload: `Error("E24")` (selector `0x08c379a0` + string `"E24"`)
- E24 means: **no enough stake to subtract/unbind**

---

## 3. Root Cause

### 3.1 Where E24 Is Raised

- **Staking.sol**: `require(vInfo.stake >= _amount, "E24")` (before subStakeOrDelegation)
- **Validator.sol**: inside `innerSubDelegation`, `require(dlg.stake >= _stake, "E24")` (before subtracting)

The revert occurred in **Validator** inside `innerSubDelegation`.

### 3.2 Logic Bug in exitDelegation

Original `Validator.exitDelegation` flow (simplified):

```text
1. Delegation memory dlg = delegators[_delegator];   // snapshot (e.g. stake = 5 ETH)
2. require(dlg.stake > 0, "E34");
3. handleDelegatorPunishment(_delegator);             // may reduce storage stake (e.g. 5 → 4 ETH)
4. uint oldStake = dlg.stake;                         // still uses snapshot: 5 ETH
5. innerSubDelegation(oldStake, _delegator, true);   // asks to subtract 5 ETH from current storage
```

Inside `innerSubDelegation`:

```text
Delegation storage dlg = delegators[_delegator];     // current storage (after punishment, e.g. 4 ETH)
require(dlg.stake >= _stake, "E24");                 // 4 >= 5 → false → revert E24
```

**Root cause in short**:

- `handleDelegatorPunishment` **writes to storage** and can reduce this delegator’s `stake`.
- `exitDelegation` still uses the **pre-punishment snapshot** `dlg.stake` (memory) as the amount to exit (`oldStake`).
- `innerSubDelegation` uses **current storage** `dlg.stake`. If punishment already reduced it, we end up requiring “subtract more than current balance” and hit **E24**.

So: **When there is a punishment slash, exitDelegation subtracts “pre-punishment amount” from “post-punishment balance”, causing E24.**

### 3.3 Why Punishment Was Applied

- When the validator is punished (e.g. lazy punish, double sign), `accPunishFactor` is updated.
- Each delegator has `punishFree` (last applied punish factor). When `accPunishFactor > punishFree`, `handleDelegatorPunishment` slashes this delegator’s stake (and pending unbound) proportionally.
- At block 14198997, this delegator had pending punishment, so `handleDelegatorPunishment` reduced their stake, then using the old stake for exit triggered E24.

---

## 4. Fix

### 4.1 Code Change

**File**: `contracts/Validator.sol`  
**Function**: `exitDelegation`

**Idea**: After `handleDelegatorPunishment`, use the **current storage** stake as the amount to exit, then call `innerSubDelegation`, so we never ask to subtract more than the current balance.

**Before**:

```solidity
handleDelegatorPunishment(_delegator);

uint oldStake = dlg.stake;
RankingOp op = innerSubDelegation(oldStake, _delegator, true);
return (op, oldStake);
```

**After**:

```solidity
handleDelegatorPunishment(_delegator);

// Use current stake after punishment; punishment may have slashed part of the delegation.
uint stakeToExit = delegators[_delegator].stake;
require(stakeToExit > 0, "E34");
RankingOp op = innerSubDelegation(stakeToExit, _delegator, true);
return (op, stakeToExit);
```

### 4.2 Behavior After Fix

- If there is remaining stake after punishment: exit **all current remaining** delegation and return `stakeToExit` to Staking; `afterLessStake(_val, val, stake, op)` uses this value, matching on-chain state.
- If stake is slashed to zero: `require(stakeToExit > 0, "E34")` reverts with E34 (no delegation), which is correct.
- The “subtract more than current stake” E24 case no longer occurs.

---

## 5. Conclusion and Recommendations

### 5.1 Conclusion

| Item | Conclusion |
|------|------------|
| Direct revert reason | **E24** (no enough stake to subtract/unbind) |
| Root cause | In Validator, `exitDelegation` used pre-punishment stake as the amount to subtract, inconsistent with post-punishment storage balance |
| Trigger condition | Delegator had pending punishment (`accPunishFactor > punishFree`), so `handleDelegatorPunishment` reduced stake before exit used the old amount |
| Overflow / div-by-zero | Analysis and on-chain data show the revert was **not** due to overflow or Staking div-by-zero; E24 was a logic bug |

### 5.2 Recommendations

1. **Contract release / upgrade**: Include this Validator change in the next testnet/mainnet deployment and test thoroughly (including “exitDelegation after punishment”).
2. **Regression tests**: Run or add unit/integration tests covering `exitDelegation`, `handleDelegatorPunishment`, and `subDelegation`.
3. **Keep diagnostic scripts**: `scripts/debug-exit-delegation.js` and `scripts/debug-tx-revert.js` are useful for future on-chain and revert analysis.

---

## 6. Appendix

### 6.1 Related Error Codes (excerpt)

| Code | Message |
|------|---------|
| E24 | no enough stake to subtract/unbind |
| E28 | can't do staking at current state |
| E34 | no delegation |

Full list: `contracts/revert_error_code.md`.

### 6.2 Diagnostic Script Usage

```bash
# On-chain state check (set RPC if needed)
RPC_URL=https://rpc-testnet.nerochain.io node scripts/debug-exit-delegation.js

# Revert reason from tx hash
node scripts/debug-tx-revert.js 0xbf139b385843546c0329239b0585b7c6cd40ce7efa3e07f7de8f817ff2682bb1
```

### 6.3 Failing Transaction Details

- **TxHash**: `0xbf139b385843546c0329239b0585b7c6cd40ce7efa3e07f7de8f817ff2682bb1`
- **Block**: 14198997
- **From**: `0xa0a73dbcbB0230dDf278cedD8Cdf93c6CbA1824F`
- **To**: `0x000000000000000000000000000000000000f000` (Staking)
- **Calldata**: `exitDelegation(0x52D8Fb6216EE63b76D22208E0B474ec124a00965)`
- **Revert**: `Error("E24")`

### 6.4 On-Chain Parameters and Simulation Reproduce

The script `scripts/simulate-exit-delegation-revert.js` fetches on-chain Validator state and simulates `handleDelegatorPunishment` and the `innerSubDelegation` check, reproducing E24 and matching the documented conclusion.

**Usage** (RPC default `https://rpc-testnet.nerochain.io`):

```bash
node scripts/simulate-exit-delegation-revert.js 0xbf139b385843546c0329239b0585b7c6cd40ce7efa3e07f7de8f817ff2682bb1
```

**Example output** (at “latest” state):

- On-chain: `accPunishFactor=28`, `punishFree=0`, `delegators(delegator).stake=5 ETH`
- Simulated punishment: `deltaFactor=28`, `punishmentAmount = 5e18 * 28 / 1000 = 0.14 ETH`, `stakeAfterPunishment = 4.86 ETH`
- **Original logic**: `oldStake = 5 ETH` (pre-punishment snapshot); in `innerSubDelegation`, `dlg.stake = 4.86 ETH` (post-punishment) → `4.86 >= 5` is false → **revert E24**
- **Fixed logic**: `stakeToExit = 4.86 ETH` (current stake after punishment) → `4.86 >= 4.86` is true → execution succeeds

This aligns with sections 3–5: revert cause is E24; root cause is using pre-punishment amount after punishment; fix is to use post-punishment stake.
